### PR TITLE
Fix mkdocs annotation formatting

### DIFF
--- a/docs/docs/background_quickstart.md
+++ b/docs/docs/background_quickstart.md
@@ -37,7 +37,7 @@ from langgraph.store.memory import InMemoryStore
 
 from langmem import ReflectionExecutor, create_memory_store_manager
 
-store = InMemoryStore( # (4)
+store = InMemoryStore( # (1)!
     index={
         "dims": 1536,
         "embed": "openai:text-embedding-3-small",
@@ -49,7 +49,7 @@ llm = init_chat_model("anthropic:claude-3-5-sonnet-latest")
 memory_manager = create_memory_store_manager(
     "anthropic:claude-3-5-sonnet-latest",
     # Store memories in the "memories" namespace (aka directory)
-    namespace=("memories",),  # (1)
+    namespace=("memories",),  # (2)!
 )
 
 @entrypoint(store=store)  # Create a LangGraph workflow
@@ -59,7 +59,7 @@ async def chat(message: str):
     # memory_manager extracts memories from conversation history
     # We'll provide it in OpenAI's message format
     to_process = {"messages": [{"role": "user", "content": message}] + [response]}
-    await memory_manager.ainvoke(to_process)  # (2)
+    await memory_manager.ainvoke(to_process)  # (3)!
     return response.content
 # Run conversation as normal
 response = await chat.ainvoke(
@@ -69,16 +69,14 @@ print(response)
 # Output: That's nice! Dogs make wonderful companions. Fido is a classic dog name. What kind of dog is Fido?
 ```
 
-1. The `namespace` parameter lets you isolate memories that are stored and retrieved. In this example, we store memories in a global "memories" path, but you could instead use template variables to scope to a user-specific path based on configuration. See [how to dynamically configure namespaces](guides/dynamically_configure_namespaces.md) for more information.
-
-2. We are using the memory manager to process the conversation every time a new message arrives. For more efficient processing patterns that let you debounce (aka avoid redundant) work, see [Delayed Memory Processing](guides/delayed_processing.md).
-
-3. You can also process memories directly with `memory_manager.process(messages)` if you don't need background processing
-
-4. What's a store? It's a document store you can add vector-search too. The "InMemoryStore" is, as it says, saved in-memory and not persistent.
+1. What's a store? It's a document store you can add vector-search too. The "InMemoryStore" is, as it says, saved in-memory and not persistent.
 
     !!! tip "For Production"
     Use a persistent store like [`AsyncPostgresStore`](https://langchain-ai.github.io/langgraph/reference/store/#langgraph.store.postgres.AsyncPostgresStore) instead of `InMemoryStore` to persist data between restarts.
+
+2. The `namespace` parameter lets you isolate memories that are stored and retrieved. In this example, we store memories in a global "memories" path, but you could instead use template variables to scope to a user-specific path based on configuration. See [how to dynamically configure namespaces](guides/dynamically_configure_namespaces.md) for more information.
+
+3. We are using the memory manager to process the conversation every time a new message arrives. For more efficient processing patterns that let you debounce (aka avoid redundant) work, see [Delayed Memory Processing](guides/delayed_processing.md). You can also process memories directly with `memory_manager.process(messages)` if you don't need background processing.
 
 
 If you want to see what memories have been extracted, you can search the store:

--- a/docs/docs/guides/extract_episodic_memories.md
+++ b/docs/docs/guides/extract_episodic_memories.md
@@ -16,7 +16,7 @@ from langmem import create_memory_manager
 from pydantic import BaseModel, Field
 
 
-class Episode(BaseModel):  # (1)
+class Episode(BaseModel):  # (1)!
     """Write the episode from the perspective of the agent within it. Use the benefit of hindsight to record the memory, saving the agent's key internal thought process so it can learn over time."""
 
     observation: str = Field(..., description="The context and setup - what happened")
@@ -34,19 +34,16 @@ class Episode(BaseModel):  # (1)
         description="Outcome and retrospective. What did you do well? What could you do better next time? I ...",
     )
 
-
-# (2) The Episode schema becomes part of the memory manager's prompt,
-# helping it extract complete reasoning chains that guide future responses
 manager = create_memory_manager(
     "anthropic:claude-3-5-sonnet-latest",
-    schemas=[Episode],
+    schemas=[Episode],  # (2)!
     instructions="Extract examples of successful explanations, capturing the full chain of reasoning. Be concise in your explanations and precise in the logic of your reasoning.",
     enable_inserts=True,
 )
 ```
 
 1. Unlike semantic triples that store facts, episodes capture the full context of successful interactions
-2. Manager extracts complete episodes, not just individual facts
+2. The Episode schema becomes part of the memory manager's prompt, helping it extract complete reasoning chains that guide future responses. The manager extracts complete episodes, not just individual facts.
 
 After a successful explanation:
 

--- a/docs/docs/guides/extract_semantic_memories.md
+++ b/docs/docs/guides/extract_semantic_memories.md
@@ -33,11 +33,10 @@ manager = create_memory_manager(
 
 1. LangMem has two similar objects for extracting and enriching memory collections:
 
-   - `create_memory_manager`: (this examples) You control storage and updates
-   - `create_memory_store_manager`: Handles the memory search, upserts, and deletes directly in whichever BaseStore is configured
-   for the graph context
+    - `create_memory_manager`: (this examples) You control storage and updates
+    - `create_memory_store_manager`: Handles the memory search, upserts, and deletes directly in whichever BaseStore is configured for the graph context
 
-   The latter uses the former. Both of these work by prompting an LLM to use parallel tool calling to extract new memories, update old ones, and (if configured) delete old ones.
+    The latter uses the former. Both of these work by prompting an LLM to use parallel tool calling to extract new memories, update old ones, and (if configured) delete old ones.
 
 2. Here our custom "`Triple`" memory schema shapes memory extraction. Without context, memories can be ambiguous when retrieved later:
     ```python

--- a/docs/docs/guides/memory_tools.md
+++ b/docs/docs/guides/memory_tools.md
@@ -22,7 +22,7 @@ store = InMemoryStore(
         "dims": 1536,
         "embed": "openai:text-embedding-3-small",
     }
-) # (1)
+) # (1)!
 ```
 
 1. For production deployments, use a persistent store like [`AsyncPostgresStore`](https://langchain-ai.github.io/langgraph/reference/store/#langgraph.store.postgres.AsyncPostgresStore). `InMemoryStore` works fine for development but doesn't persist data between restarts.

--- a/docs/docs/guides/use_tools_in_crewai.md
+++ b/docs/docs/guides/use_tools_in_crewai.md
@@ -29,7 +29,7 @@ store = InMemoryStore(
         "dims": 1536,
         "embed": "openai:text-embedding-3-small",
     }
-)  # (1)
+)  # (1)!
 
 # Create memory tools
 memory_tools = [

--- a/docs/docs/guides/use_tools_in_custom_agent.md
+++ b/docs/docs/guides/use_tools_in_custom_agent.md
@@ -104,7 +104,7 @@ store = InMemoryStore(
                 "dims": 1536,
                 "embed": "openai:text-embedding-3-small",
             }
-        )  # (1)
+        )  # (1)!
 memory_tools = [
     create_manage_memory_tool(namespace="memories", store=store),
     create_search_memory_tool(namespace="memories", store=store),


### PR DESCRIPTION
Fixing various cases of improperly formatted mkdocs annotations by:

1. Ensuring that the `#` is not visible in the code by adding a `!` to the annotation
2. Ensuring that the proper text content is in the popup by fixing spacing issues

For example, for one case, here's the before:

<img width="816" alt="Screenshot 2025-04-02 at 7 52 22 AM" src="https://github.com/user-attachments/assets/00ce03a0-cd29-433a-9b95-4f43ce0b7ba8" />

And the after:

<img width="786" alt="Screenshot 2025-04-02 at 7 58 45 AM" src="https://github.com/user-attachments/assets/3d2bab98-37ee-4b6f-ace6-7a1d75cf2306" />
