### PR TITLE
fix: include all messages in summarization when token threshold is exceeded

### DIFF
--- a/src/langmem/short_term/summarization.py
+++ b/src/langmem/short_term/summarization.py
@@ -242,6 +242,9 @@ def summarize_messages(
         # If we're still under max_tokens_to_summarize, update the potential cutoff point
         if n_tokens <= max_tokens_to_summarize:
             idx = i
+        else:
+            idx = len(messages) - 1
+            break
 
         # Check if we've exceeded the absolute maximum
         if n_tokens > max_total_tokens:


### PR DESCRIPTION
1. If the accumulated token count stays below `max_tokens_to_summarize`, it behaves like before, setting the cutoff point at the last message that fits within the token budget
2. **But the key improvement**: As soon as the token count exceeds `max_tokens_to_summarize`, it sets `idx` to include ALL remaining messages and exits the loop

This approach has several benefits:
- It preserves the gradual, incremental summarization for short conversations
- It avoids the "small chunk" problem where only a few messages get summarized at a time
- It ensures all unsummarized messages are included when the conversation gets long