### PR TITLE
fix: resolve schema mismatch between hot and cold memory paths

### DIFF
--- a/src/langmem/knowledge/extraction.py
+++ b/src/langmem/knowledge/extraction.py
@@ -41,6 +41,28 @@ from langmem.knowledge.tools import create_search_memory_tool
 # ```  # end-setup
 
 
+
+
+def _parse_store_value(value: dict) -> tuple[str, dict]:
+    """Parse a store item value into (kind, content), handling both formats.
+
+    The manage_memory_tool (hot path) writes: {"content": <str_or_dict>}
+    The MemoryStoreManager (cold path) writes: {"kind": "Memory", "content": {...}}
+
+    This function normalizes both formats into a (kind, content) tuple so that
+    the two code paths can coexist without KeyError.
+    """
+    if "kind" in value and "content" in value:
+        return value["kind"], value["content"]
+    if "content" in value:
+        content = value["content"]
+        if isinstance(content, str):
+            return "Memory", {"content": content}
+        if isinstance(content, dict):
+            return "Memory", content
+        return "Memory", {"content": content}
+    return "Memory", value
+
 class Item(BaseItem):
     value: BaseModel | dict[str, typing.Any]
 
@@ -1063,7 +1085,7 @@ class MemoryStoreManager(Runnable[MemoryStoreManagerInput, list[dict]]):
             )
 
         store_based = [
-            (sid, item.value["kind"], item.value["content"])
+            (sid, *_parse_store_value(item.value))
             for sid, item in store_map.items()
         ]
         ephemeral: list[tuple[str, str, dict]] = []
@@ -1106,7 +1128,8 @@ class MemoryStoreManager(Runnable[MemoryStoreManagerInput, list[dict]]):
                 continue
             if sid in store_map:
                 old_art = store_map[sid]
-                if old_art.value["kind"] != kind or old_art.value["content"] != content:
+                old_kind, old_content = _parse_store_value(old_art.value)
+                if old_kind != kind or old_content != content:
                     final_puts.append(
                         {
                             "namespace": old_art.namespace,
@@ -1207,7 +1230,7 @@ class MemoryStoreManager(Runnable[MemoryStoreManagerInput, list[dict]]):
                 self.query_limit,
             )
         store_based = [
-            (sid, item.value["kind"], item.value["content"])
+            (sid, *_parse_store_value(item.value))
             for sid, item in store_map.items()
         ]
         ephemeral: list[tuple[str, str, dict]] = []
@@ -1248,7 +1271,8 @@ class MemoryStoreManager(Runnable[MemoryStoreManagerInput, list[dict]]):
                 continue
             if sid in store_map:
                 old_art = store_map[sid]
-                if old_art.value["kind"] != kind or old_art.value["content"] != content:
+                old_kind, old_content = _parse_store_value(old_art.value)
+                if old_kind != kind or old_content != content:
                     final_puts.append(
                         {
                             "namespace": old_art.namespace,

--- a/src/langmem/knowledge/tools.py
+++ b/src/langmem/knowledge/tools.py
@@ -449,9 +449,14 @@ def create_search_memory_tool(
             limit=limit,
             offset=offset,
         )
+        normalized = []
+        for m in memories:
+            d = m.dict()
+            d["value"] = _normalize_memory_value(d.get("value", {}))
+            normalized.append(d)
         if response_format == "content_and_artifact":
-            return utils.dumps([m.dict() for m in memories]), memories
-        return utils.dumps([m.dict() for m in memories])
+            return utils.dumps(normalized), memories
+        return utils.dumps(normalized)
 
     def search_memory(
         query: str,
@@ -469,9 +474,14 @@ def create_search_memory_tool(
             limit=limit,
             offset=offset,
         )
+        normalized = []
+        for m in memories:
+            d = m.dict()
+            d["value"] = _normalize_memory_value(d.get("value", {}))
+            normalized.append(d)
         if response_format == "content_and_artifact":
-            return utils.dumps([m.dict() for m in memories]), memories
-        return utils.dumps([m.dict() for m in memories])
+            return utils.dumps(normalized), memories
+        return utils.dumps(normalized)
 
     description = """Search your long-term memories for information relevant to your current context. {instructions}""".format(
         instructions=instructions
@@ -484,6 +494,19 @@ def create_search_memory_tool(
         description=description,
         response_format=response_format,
     )
+
+
+
+def _normalize_memory_value(value):
+    """Normalize memory value for consistent presentation to the LLM.
+
+    Unwraps the kind/content envelope written by MemoryStoreManager so that
+    search results have a consistent format regardless of which code path
+    wrote the memory.
+    """
+    if isinstance(value, dict) and "kind" in value and "content" in value:
+        return value["content"]
+    return value
 
 
 def _get_store(initial_store: BaseStore | None = None) -> BaseStore:

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -1,0 +1,104 @@
+"""Tests for schema compatibility between hot path and cold path memory operations.
+
+Verifies fixes for:
+- Issue #138: MemoryStoreManager crashes when reading memories written by
+  create_manage_memory_tool due to missing "kind" key.
+- Issue #140: create_search_memory_tool returns nested/inconsistent format
+  for memories written by MemoryStoreManager.
+"""
+
+import pytest
+
+from langmem.knowledge.extraction import _parse_store_value
+from langmem.knowledge.tools import _normalize_memory_value
+
+
+class TestParseStoreValue:
+    """Test _parse_store_value handles both hot path and cold path formats."""
+
+    def test_cold_path_format(self):
+        """Cold path (MemoryStoreManager) writes {"kind": "Memory", "content": {...}}."""
+        value = {"kind": "Memory", "content": {"content": "User likes Python"}}
+        kind, content = _parse_store_value(value)
+        assert kind == "Memory"
+        assert content == {"content": "User likes Python"}
+
+    def test_cold_path_custom_schema(self):
+        """Cold path with custom Pydantic schema."""
+        value = {"kind": "UserProfile", "content": {"name": "Alice", "age": 30}}
+        kind, content = _parse_store_value(value)
+        assert kind == "UserProfile"
+        assert content == {"name": "Alice", "age": 30}
+
+    def test_hot_path_string_content(self):
+        """Hot path (manage_memory_tool) writes {"content": "bare string"} for str schema."""
+        value = {"content": "User is a data engineer"}
+        kind, content = _parse_store_value(value)
+        assert kind == "Memory"
+        assert content == {"content": "User is a data engineer"}
+
+    def test_hot_path_dict_content(self):
+        """Hot path with custom Pydantic schema serialized to dict."""
+        value = {"content": {"name": "Alice", "age": 30}}
+        kind, content = _parse_store_value(value)
+        assert kind == "Memory"
+        assert content == {"name": "Alice", "age": 30}
+
+    def test_hot_path_numeric_content(self):
+        """Hot path with numeric content (edge case)."""
+        value = {"content": 42}
+        kind, content = _parse_store_value(value)
+        assert kind == "Memory"
+        assert content == {"content": 42}
+
+    def test_empty_dict(self):
+        """Edge case: empty dict."""
+        value = {}
+        kind, content = _parse_store_value(value)
+        assert kind == "Memory"
+        assert content == {}
+
+    def test_unknown_keys(self):
+        """Edge case: dict with unknown keys and no content."""
+        value = {"foo": "bar"}
+        kind, content = _parse_store_value(value)
+        assert kind == "Memory"
+        assert content == {"foo": "bar"}
+
+
+class TestNormalizeMemoryValue:
+    """Test _normalize_memory_value unwraps cold path envelope for search results."""
+
+    def test_cold_path_envelope(self):
+        """Cold path envelope should be unwrapped."""
+        value = {"kind": "Memory", "content": {"content": "User likes Python"}}
+        result = _normalize_memory_value(value)
+        assert result == {"content": "User likes Python"}
+
+    def test_cold_path_custom_schema(self):
+        """Custom schema envelope should be unwrapped."""
+        value = {"kind": "UserProfile", "content": {"name": "Alice", "age": 30}}
+        result = _normalize_memory_value(value)
+        assert result == {"name": "Alice", "age": 30}
+
+    def test_hot_path_passthrough(self):
+        """Hot path format should pass through unchanged."""
+        value = {"content": "User is a data engineer"}
+        result = _normalize_memory_value(value)
+        assert result == {"content": "User is a data engineer"}
+
+    def test_non_dict_passthrough(self):
+        """Non-dict values should pass through unchanged."""
+        assert _normalize_memory_value("hello") == "hello"
+        assert _normalize_memory_value(42) == 42
+        assert _normalize_memory_value(None) is None
+
+    def test_empty_dict(self):
+        """Empty dict should pass through."""
+        assert _normalize_memory_value({}) == {}
+
+    def test_partial_envelope(self):
+        """Dict with only 'kind' but no 'content' should pass through."""
+        value = {"kind": "Memory", "data": "something"}
+        result = _normalize_memory_value(value)
+        assert result == {"kind": "Memory", "data": "something"}


### PR DESCRIPTION
## Summary

- **Fixes #138**: `MemoryStoreManager` crashes with `KeyError: 'kind'` when reading memories written by `create_manage_memory_tool`
- **Fixes #140**: `create_search_memory_tool` returns nested/inconsistent format for memories written by `MemoryStoreManager`

## Problem

The two memory write paths use incompatible value schemas:

| Path | Writes |
|---|---|
| `create_manage_memory_tool` (hot) | `{"content": <str_or_dict>}` |
| `MemoryStoreManager` (cold) | `{"kind": "Memory", "content": {...}}` |

When both paths coexist (which is the recommended pattern per docs), the cold path crashes on `item.value["kind"]` because the hot path never writes a `kind` key.

## Solution

**Backward-compatible read-side fix** — no changes to write formats, no breaking changes.

- **`_parse_store_value()`** in `extraction.py`: Normalizes both formats into a `(kind, content)` tuple. If `kind` is missing, defaults to `"Memory"` and wraps bare strings into the expected dict format.
- **`_normalize_memory_value()`** in `tools.py`: Unwraps the `kind/content` envelope in search results so the LLM always sees a consistent, flat value regardless of which code path wrote the memory.

Both helpers are used in all 4 affected code locations (2 in `ainvoke`, 2 in `invoke`).

## Tests

Added 13 unit tests in `tests/test_schema_compat.py` covering:
- Cold path format (with and without custom schemas)
- Hot path format (string content, dict content, numeric edge case)
- Edge cases (empty dict, unknown keys, partial envelope)
- Normalization passthrough for non-dict values