### PR TITLE
Clarify summarization trimming warning

### DIFF
--- a/src/langmem/short_term/summarization.py
+++ b/src/langmem/short_term/summarization.py
@@ -244,8 +244,11 @@ def _adjust_messages_before_summarization(
         )
         if not adjusted_messages_to_summarize:
             warnings.warn(
-                "Failed to trim messages to fit within max_tokens limit before summarization - "
-                "falling back to the original message list. "
+                "Failed to trim messages to fit within max_tokens limit before summarization. "
+                "No HumanMessage was found within the retained message window. "
+                "Increase `max_tokens` or decrease `max_tokens_before_summary` "
+                "so the retained window includes a HumanMessage. "
+                "Falling back to the original message list. "
                 "This may lead to exceeding the context window of the summarization LLM.",
                 RuntimeWarning,
             )
@@ -376,6 +379,11 @@ def summarize_messages(
                 If the number of tokens to be summarized is greater than max_tokens, only the last max_tokens amongst those
                 will be summarized. This is done to prevent exceeding the context window of the summarization LLM
                 (assumed to be capped at max_tokens).
+
+                The retained message window must include a `HumanMessage`. If trimming cannot find one,
+                the function emits a `RuntimeWarning` and falls back to the original message list.
+                Increase `max_tokens` or decrease `max_tokens_before_summary` so the retained window
+                includes a `HumanMessage`.
         max_summary_tokens: Maximum number of tokens to budget for the summary.
 
             !!! Note
@@ -537,6 +545,11 @@ async def asummarize_messages(
                 If the number of tokens to be summarized is greater than max_tokens, only the last max_tokens amongst those
                 will be summarized. This is done to prevent exceeding the context window of the summarization LLM
                 (assumed to be capped at max_tokens).
+
+                The retained message window must include a `HumanMessage`. If trimming cannot find one,
+                the function emits a `RuntimeWarning` and falls back to the original message list.
+                Increase `max_tokens` or decrease `max_tokens_before_summary` so the retained window
+                includes a `HumanMessage`.
         max_summary_tokens: Maximum number of tokens to budget for the summary.
 
             !!! Note
@@ -698,6 +711,11 @@ class SummarizationNode(RunnableCallable):
                     If the number of tokens to be summarized is greater than max_tokens, only the last max_tokens amongst those
                     will be summarized. This is done to prevent exceeding the context window of the summarization LLM
                     (assumed to be capped at max_tokens).
+
+                    The retained message window must include a `HumanMessage`. If trimming cannot find one,
+                    the node emits a `RuntimeWarning` and falls back to the original message list.
+                    Increase `max_tokens` or decrease `max_tokens_before_summary` so the retained window
+                    includes a `HumanMessage`.
             max_summary_tokens: Maximum number of tokens to budget for the summary.
 
                 !!! Note

--- a/tests/short_term/test_summarization.py
+++ b/tests/short_term/test_summarization.py
@@ -205,6 +205,37 @@ def test_max_tokens_before_summary():
     assert result.messages[1:] == messages[-1:]
 
 
+def test_warns_when_trimmed_window_has_no_human_message():
+    model = FakeChatModel(
+        responses=[AIMessage(content="This is a summary of the conversation.")]
+    )
+    messages = [
+        HumanMessage(content="Message 1", id="1"),
+        AIMessage(content="Response 1", id="2"),
+        AIMessage(content="Response 2", id="3"),
+        AIMessage(content="Response 3", id="4"),
+        AIMessage(content="Response 4", id="5"),
+        HumanMessage(content="Latest message", id="6"),
+    ]
+
+    with pytest.warns(
+        RuntimeWarning,
+        match=(
+            "No HumanMessage was found within the retained message window.*"
+            "Increase `max_tokens` or decrease `max_tokens_before_summary`"
+        ),
+    ):
+        summarize_messages(
+            messages,
+            running_summary=None,
+            model=model,
+            token_counter=len,
+            max_tokens=4,
+            max_tokens_before_summary=5,
+            max_summary_tokens=1,
+        )
+
+
 def test_with_system_message():
     """Test summarization with a system message present."""
     model = FakeChatModel(

--- a/tests/short_term/test_summarization_async.py
+++ b/tests/short_term/test_summarization_async.py
@@ -207,6 +207,37 @@ async def test_max_tokens_before_summary():
     assert result.messages[1:] == messages[-1:]
 
 
+async def test_warns_when_trimmed_window_has_no_human_message():
+    model = FakeChatModel(
+        responses=[AIMessage(content="This is a summary of the conversation.")]
+    )
+    messages = [
+        HumanMessage(content="Message 1", id="1"),
+        AIMessage(content="Response 1", id="2"),
+        AIMessage(content="Response 2", id="3"),
+        AIMessage(content="Response 3", id="4"),
+        AIMessage(content="Response 4", id="5"),
+        HumanMessage(content="Latest message", id="6"),
+    ]
+
+    with pytest.warns(
+        RuntimeWarning,
+        match=(
+            "No HumanMessage was found within the retained message window.*"
+            "Increase `max_tokens` or decrease `max_tokens_before_summary`"
+        ),
+    ):
+        await asummarize_messages(
+            messages,
+            running_summary=None,
+            model=model,
+            token_counter=len,
+            max_tokens=4,
+            max_tokens_before_summary=5,
+            max_summary_tokens=1,
+        )
+
+
 async def test_with_system_message():
     """Test summarization with a system message present."""
     model = FakeChatModel(


### PR DESCRIPTION
## Summary

- clarify the fallback warning when message trimming cannot retain a `HumanMessage`
- document how `max_tokens` and `max_tokens_before_summary` affect the retained message window
- add synchronous and asynchronous regression coverage for the failing configuration

## Root cause

Summarization trims the candidate messages with `start_on="human"`. When the retained token window contains no `HumanMessage`, trimming returns an empty list and the existing warning only reports a generic trimming failure. This makes the configuration problem difficult to diagnose.

The updated warning identifies the missing `HumanMessage`, suggests the relevant parameter adjustments, and preserves the existing fallback behavior.

## Validation

- `pytest -q -m "not langsmith"`: 32 passed, 27 deselected
- targeted synchronous and asynchronous regression tests pass
- Ruff checks pass for the changed implementation and tests
- `python -m compileall -q src/langmem`
- `git diff --check`

Closes #156
