### PR TITLE
fix(prompts): use portable forced tool choice

### DIFF
--- a/src/langmem/prompts/optimization.py
+++ b/src/langmem/prompts/optimization.py
@@ -334,7 +334,7 @@ class MultiPromptOptimizer(
                     return self
 
             classifier = create_extractor(
-                self.model, tools=[Classify], tool_choice="Classify"
+                self.model, tools=[Classify], tool_choice="any"
             )
             prompt_joined_content = "".join(
                 f"{p['name']}: {p['prompt']}\n" for p in prompts
@@ -421,7 +421,7 @@ Return JSON with "which": [...], listing the names of prompts that need updates.
                     return self
 
             classifier = create_extractor(
-                self.model, tools=[Classify], tool_choice="Classify"
+                self.model, tools=[Classify], tool_choice="any"
             )
             prompt_joined_content = "".join(
                 f"{p['name']}: {p['prompt']}\n" for p in prompts

--- a/tests/test_prompt_optimization.py
+++ b/tests/test_prompt_optimization.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from langmem.prompts import optimization
+
+
+class _StubOptimizer:
+    def invoke(self, *args: Any, **kwargs: Any) -> str:
+        return "unchanged"
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> str:
+        return "unchanged"
+
+
+class _StubClassifier:
+    def invoke(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"responses": [SimpleNamespace(which=[])]}
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"responses": [SimpleNamespace(which=[])]}
+
+
+def _multi_prompt_input() -> dict[str, Any]:
+    return {
+        "trajectories": "No prompt needs updating.",
+        "prompts": [
+            {"name": "first", "prompt": "First prompt"},
+            {"name": "second", "prompt": "Second prompt"},
+        ],
+    }
+
+
+def _create_optimizer(monkeypatch: pytest.MonkeyPatch, tool_choices: list[str]):
+    monkeypatch.setattr(
+        optimization,
+        "create_prompt_optimizer",
+        lambda *args, **kwargs: _StubOptimizer(),
+    )
+
+    def create_extractor(*args: Any, tool_choice: str, **kwargs: Any):
+        tool_choices.append(tool_choice)
+        return _StubClassifier()
+
+    monkeypatch.setattr(optimization, "create_extractor", create_extractor)
+    return optimization.MultiPromptOptimizer("openai:test")
+
+
+def test_multi_prompt_optimizer_uses_portable_tool_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_choices: list[str] = []
+    optimizer = _create_optimizer(monkeypatch, tool_choices)
+
+    optimizer.invoke(_multi_prompt_input())
+
+    assert tool_choices == ["any"]
+
+
+@pytest.mark.anyio
+async def test_multi_prompt_optimizer_uses_portable_tool_choice_async(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_choices: list[str] = []
+    optimizer = _create_optimizer(monkeypatch, tool_choices)
+
+    await optimizer.ainvoke(_multi_prompt_input())
+
+    assert tool_choices == ["any"]


### PR DESCRIPTION
## Summary

Fixes #176

- force the single classification tool through LangChain’s portable `any` abstraction
- cover sync and async multi-prompt optimizer paths

`any` is intentional: ChatOpenAI converts it to the OpenAI-compatible `required` wire value accepted by LM Studio, while Anthropic converts it to its native `{"type":"any"}` shape. Passing raw `required` would be interpreted as a tool name by Anthropic.

## Tests

- `make lint`
- `uv run --frozen pytest tests/short_term tests/test_prompt_optimization.py -q` (32 passed)
- `uv run --frozen pytest -q` (35 passed; 24 docstring examples require external OpenAI/Anthropic credentials or services in this environment)

## AI Disclosure

This bug was investigated and fixed with AI assistance. I reviewed the provider-specific tool-choice behavior and verified the implementation.