### PR TITLE
docs: document OrcaRouter as a named provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,31 @@ agent = create_react_agent(
 )
 ```
 
+Alternatively, use [OrcaRouter](https://www.orcarouter.ai) as your model. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key (`sk-orca-...`). Pass a `ChatOpenAI` instance pointed at its OpenAI-compatible endpoint:
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="openai/gpt-4o-mini",
+    base_url="https://api.orcarouter.ai/v1",
+    api_key="sk-orca-...",  # or set ORCAROUTER_API_KEY
+)
+agent = create_react_agent(
+    llm,
+    tools=[
+        create_manage_memory_tool(namespace=("memories",)),
+        create_search_memory_tool(namespace=("memories",)),
+    ],
+    store=store,
+)
+```
+
+> [!NOTE]
+> OrcaRouter routes by the namespaced model id, so keep the `openai/` prefix in the `model`
+> argument (e.g. `openai/gpt-4o-mini`). If you use `init_chat_model("openai:openai/gpt-4o-mini", ...)`,
+> the extra `openai:` prefix is required because LangChain strips one provider prefix.
+
 1. The memory tools work in any LangGraph app. Here we use [`create_react_agent`](https://langchain-ai.github.io/langgraph/reference/prebuilt/#langgraph.prebuilt.create_react_agent) to run an LLM with tools, but you can add these tools to your existing agents or build [custom memory systems](concepts/conceptual_guide.md#functional-core) without agents.
 
 2. [`InMemoryStore`](https://langchain-ai.github.io/langgraph/reference/store/#langgraph.store.memory.InMemoryStore) keeps memories in process memory—they'll be lost on restart. For production, use the [AsyncPostgresStore](https://langchain-ai.github.io/langgraph/reference/store/#langgraph.store.postgres.AsyncPostgresStore) or a similar DB-backed store to persist memories across server restarts.

--- a/docs/docs/background_quickstart.md
+++ b/docs/docs/background_quickstart.md
@@ -69,6 +69,27 @@ print(response)
 # Output: That's nice! Dogs make wonderful companions. Fido is a classic dog name. What kind of dog is Fido?
 ```
 
+!!! note "Use OrcaRouter as your model"
+    [OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that
+    exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a
+    single endpoint and API key (`sk-orca-...`). Pass a `ChatOpenAI` instance pointed at its
+    OpenAI-compatible endpoint to the memory manager (and use it as the `llm`):
+
+    ```python
+    from langchain_openai import ChatOpenAI
+
+    llm = ChatOpenAI(
+        model="openai/gpt-4o-mini",
+        base_url="https://api.orcarouter.ai/v1",
+        api_key="sk-orca-...",  # or set ORCAROUTER_API_KEY
+    )
+    memory_manager = create_memory_store_manager(llm, namespace=("memories",))
+    ```
+
+    OrcaRouter routes by the namespaced model id, so keep the `openai/` prefix in the `model`
+    argument. If you use `init_chat_model("openai:openai/gpt-4o-mini", ...)`, the extra `openai:`
+    prefix is required because LangChain strips one provider prefix.
+
 1. What's a store? It's a document store you can add vector-search too. The "InMemoryStore" is, as it says, saved in-memory and not persistent.
 
     !!! tip "For Production"


### PR DESCRIPTION
# Document OrcaRouter as a named provider option

## Purpose

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR documents it as a named provider option so LangMem users can opt in directly with a `ChatOpenAI` instance.

I'm an engineer on the OrcaRouter team.

LangMem's model input is a `str | BaseChatModel` (any LangChain chat model), so the named integration is a `ChatOpenAI` instance pointed at OrcaRouter's OpenAI-compatible endpoint — the same pattern the README already shows for providers like Anthropic. OrcaRouter routes by the namespaced model id, so the documented examples keep the `openai/` prefix in the `model` argument (`openai/gpt-4o-mini`).

## Changes

- `README.md` — add an "Alternatively, use OrcaRouter as your model" block after the "Creating an Agent" example, with a full `create_react_agent` example and a note about the namespaced model id.
- `docs/docs/background_quickstart.md` — add a `!!! note "Use OrcaRouter as your model"` admonition to the Background Quickstart, showing a `ChatOpenAI` instance passed to `create_memory_store_manager`.

## Test Plan

- Verified the exact documented call against the real OrcaRouter gateway through LangChain's model paths:
  - `ChatOpenAI(model="openai/gpt-4o-mini", base_url="https://api.orcarouter.ai/v1", api_key="sk-orca-...")` → 200, returns "PONG"
  - `init_chat_model("openai:openai/gpt-4o-mini", base_url=..., api_key=...)` → 200, returns "PONG" (the extra `openai:` prefix is documented because LangChain strips one provider prefix)
  - `init_chat_model("openai:gpt-4o-mini", base_url=..., api_key=...)` → 503 `model_not_found` — confirms the double-prefix note in the docs
- `mkdocs build --clean -f docs/mkdocs.yml --strict` passes with the new admonition (the docs CI for this repo).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
