### PR TITLE
fix: preserve memory schema across extraction steps

### DIFF
--- a/src/langmem/knowledge/extraction.py
+++ b/src/langmem/knowledge/extraction.py
@@ -65,8 +65,12 @@ class MessagesState(TypedDict):
     messages: list[AnyMessage]
 
 
+MemoryContent = BaseModel | dict[str, typing.Any]
+ExistingMemory = tuple[str, MemoryContent] | tuple[str, str, MemoryContent]
+
+
 class MemoryState(MessagesState):
-    existing: typing.NotRequired[list[tuple[str, BaseModel]]]
+    existing: typing.NotRequired[list[str] | list[ExistingMemory]]
     max_steps: int  # Default of 1
 
 
@@ -77,7 +81,7 @@ class SummarizeThread(BaseModel):
 
 class ExtractedMemory(typing.NamedTuple):
     id: str
-    content: BaseModel
+    content: MemoryContent
 
 
 S = typing.TypeVar("S", bound=type)
@@ -495,11 +499,7 @@ class MemoryManager(Runnable[MemoryState, list[ExtractedMemory]]):
 
     def _prepare_existing(
         self,
-        existing: typing.Optional[
-            typing.Union[
-                list[str], list[tuple[str, BaseModel]], list[tuple[str, str, dict]]
-            ]
-        ],
+        existing: typing.Optional[list[str] | list[ExistingMemory]],
     ) -> list[tuple[str, str, typing.Any]]:
         if existing is None:
             return []

--- a/src/langmem/knowledge/extraction.py
+++ b/src/langmem/knowledge/extraction.py
@@ -261,7 +261,8 @@ class MemoryManager(Runnable[MemoryState, list[ExtractedMemory]]):
         # initial payload uses the full prepared_existing list
         payload = {"messages": prepared_messages, "existing": prepared_existing}
         # Use a dict to record the latest update for each memory id.
-        results: dict[str, BaseModel] = {}
+        results: dict[str, BaseModel | dict[str, typing.Any]] = {}
+        modified_ids: set[str] = set()
 
         for i in range(max_steps):
             if i == 1:
@@ -287,6 +288,7 @@ class MemoryManager(Runnable[MemoryState, list[ExtractedMemory]]):
                 )
                 step_results[mem_id] = r
             results.update(step_results)
+            modified_ids.update(step_results)
 
             for mem_id, _, mem in prepared_existing:
                 if mem_id not in results:
@@ -328,8 +330,14 @@ class MemoryManager(Runnable[MemoryState, list[ExtractedMemory]]):
                 # For the next iteration payload, drop all removal objects.
                 payload = {
                     "messages": prepared_messages,
-                    "existing": self._filter_response(
-                        list(results.items()), external_ids, exclude_removals=True
+                    "existing": self._prepare_next_existing(
+                        self._filter_response(
+                            list(results.items()),
+                            external_ids,
+                            exclude_removals=True,
+                        ),
+                        prepared_existing,
+                        modified_ids,
                     ),
                 }
 
@@ -364,7 +372,8 @@ class MemoryManager(Runnable[MemoryState, list[ExtractedMemory]]):
         )
         payload = {"messages": prepared_messages, "existing": prepared_existing}
         # Use a dict to record the latest update for each memory id.
-        results: dict[str, BaseModel] = {}
+        results: dict[str, BaseModel | dict[str, typing.Any]] = {}
+        modified_ids: set[str] = set()
 
         for i in range(max_steps):
             if i == 1:
@@ -392,6 +401,7 @@ class MemoryManager(Runnable[MemoryState, list[ExtractedMemory]]):
                 )
                 step_results[mem_id] = r
             results.update(step_results)
+            modified_ids.update(step_results)
 
             # Ensure any memory from the initial payload that hasn't been updated is retained.
             for mem_id, _, mem in prepared_existing:
@@ -435,8 +445,14 @@ class MemoryManager(Runnable[MemoryState, list[ExtractedMemory]]):
                 )
                 payload = {
                     "messages": prepared_messages,
-                    "existing": self._filter_response(
-                        list(results.items()), external_ids, exclude_removals=True
+                    "existing": self._prepare_next_existing(
+                        self._filter_response(
+                            list(results.items()),
+                            external_ids,
+                            exclude_removals=True,
+                        ),
+                        prepared_existing,
+                        modified_ids,
                     ),
                 }
 
@@ -505,6 +521,24 @@ class MemoryManager(Runnable[MemoryState, list[ExtractedMemory]]):
                 )
                 result.append((id_, kind, value))
         return result
+
+    @staticmethod
+    def _prepare_next_existing(
+        memories: list[ExtractedMemory],
+        prepared_existing: list[tuple[str, str, typing.Any]],
+        modified_ids: set[str],
+    ) -> list[ExtractedMemory | tuple[str, str, typing.Any]]:
+        """Preserve schema names for unchanged externally loaded memories."""
+        original_by_id = {
+            memory_id: (memory_id, schema_name, content)
+            for memory_id, schema_name, content in prepared_existing
+        }
+        return [
+            original_by_id[memory.id]
+            if memory.id in original_by_id and memory.id not in modified_ids
+            else memory
+            for memory in memories
+        ]
 
     @staticmethod
     def _filter_response(

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -1,0 +1,107 @@
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from pydantic import BaseModel
+
+import langmem.knowledge.extraction as extraction
+
+pytestmark = pytest.mark.anyio
+
+
+class Triple(BaseModel):
+    subject: str
+    predicate: str
+    object: str
+
+
+class CapturingExtractor:
+    def __init__(self):
+        self.payloads = []
+
+    def _response(self, payload):
+        self.payloads.append(payload)
+        tool_calls = (
+            [
+                {
+                    "name": "Triple",
+                    "args": {},
+                    "id": "call-1",
+                    "type": "tool_call",
+                }
+            ]
+            if len(self.payloads) == 1
+            else []
+        )
+        return {
+            "responses": [],
+            "response_metadata": [],
+            "messages": [AIMessage(content="", tool_calls=tool_calls)],
+        }
+
+    def invoke(self, payload, config=None):
+        return self._response(payload)
+
+    async def ainvoke(self, payload, config=None):
+        return self._response(payload)
+
+
+def _setup_manager(monkeypatch):
+    extractor = CapturingExtractor()
+    monkeypatch.setattr(extraction, "init_chat_model", lambda model: object())
+    monkeypatch.setattr(
+        extraction, "create_extractor", lambda model, **kwargs: extractor
+    )
+    manager = extraction.MemoryManager("fake-model", schemas=[Triple])
+    return manager, extractor
+
+
+def _input():
+    return {
+        "messages": [HumanMessage(content="Alice still likes Python.")],
+        "existing": [
+            (
+                "memory-1",
+                "Triple",
+                {
+                    "subject": "Alice",
+                    "predicate": "likes",
+                    "object": "Python",
+                },
+            )
+        ],
+        "max_steps": 2,
+    }
+
+
+def _assert_schema_preserved(extractor):
+    assert extractor.payloads[1]["existing"] == _input()["existing"]
+
+
+def _assert_public_response_unchanged(result):
+    assert result == [
+        extraction.ExtractedMemory(
+            id="memory-1",
+            content={
+                "subject": "Alice",
+                "predicate": "likes",
+                "object": "Python",
+            },
+        )
+    ]
+
+
+def test_invoke_preserves_schema_for_unchanged_dict_memory(monkeypatch):
+    manager, extractor = _setup_manager(monkeypatch)
+
+    result = manager.invoke(_input())
+
+    _assert_schema_preserved(extractor)
+    _assert_public_response_unchanged(result)
+
+
+async def test_ainvoke_preserves_schema_for_unchanged_dict_memory(monkeypatch):
+    manager, extractor = _setup_manager(monkeypatch)
+
+    result = await manager.ainvoke(_input())
+
+    _assert_schema_preserved(extractor)
+    _assert_public_response_unchanged(result)

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -4,13 +4,20 @@ from pydantic import BaseModel
 
 import langmem.knowledge.extraction as extraction
 
-pytestmark = pytest.mark.anyio
-
 
 class Triple(BaseModel):
     subject: str
     predicate: str
     object: str
+
+
+class Preference(BaseModel):
+    category: str
+    value: str
+
+
+class RemoveDoc(BaseModel):
+    json_doc_id: str
 
 
 class CapturingExtractor:
@@ -44,13 +51,47 @@ class CapturingExtractor:
         return self._response(payload)
 
 
-def _setup_manager(monkeypatch):
-    extractor = CapturingExtractor()
+class SequencedExtractor:
+    def __init__(self, steps):
+        self.payloads = []
+        self.steps = steps
+
+    def _response(self, payload):
+        step_index = len(self.payloads)
+        self.payloads.append(payload)
+        responses, response_metadata = self.steps[step_index]
+        tool_calls = [
+            {
+                "name": response.__repr_name__(),
+                "args": {},
+                "id": f"call-{index}",
+                "type": "tool_call",
+            }
+            for index, response in enumerate(responses)
+        ]
+        return {
+            "responses": responses,
+            "response_metadata": response_metadata,
+            "messages": [AIMessage(content="", tool_calls=tool_calls)],
+        }
+
+    def invoke(self, payload, config=None):
+        return self._response(payload)
+
+    async def ainvoke(self, payload, config=None):
+        return self._response(payload)
+
+
+def _setup_manager(monkeypatch, *, extractor=None, schemas=None):
+    extractor = extractor or CapturingExtractor()
     monkeypatch.setattr(extraction, "init_chat_model", lambda model: object())
     monkeypatch.setattr(
         extraction, "create_extractor", lambda model, **kwargs: extractor
     )
-    manager = extraction.MemoryManager("fake-model", schemas=[Triple])
+    manager = extraction.MemoryManager(
+        "fake-model",
+        schemas=schemas or [Triple],
+    )
     return manager, extractor
 
 
@@ -98,6 +139,7 @@ def test_invoke_preserves_schema_for_unchanged_dict_memory(monkeypatch):
     _assert_public_response_unchanged(result)
 
 
+@pytest.mark.anyio
 async def test_ainvoke_preserves_schema_for_unchanged_dict_memory(monkeypatch):
     manager, extractor = _setup_manager(monkeypatch)
 
@@ -105,3 +147,66 @@ async def test_ainvoke_preserves_schema_for_unchanged_dict_memory(monkeypatch):
 
     _assert_schema_preserved(extractor)
     _assert_public_response_unchanged(result)
+
+
+def test_updated_memory_does_not_restore_stale_content_or_other_schema(
+    monkeypatch,
+):
+    updated = Triple(subject="Alice", predicate="likes", object="Rust")
+    extractor = SequencedExtractor(
+        [
+            ([updated], [{"json_doc_id": "memory-1"}]),
+            ([], []),
+        ]
+    )
+    manager, _ = _setup_manager(
+        monkeypatch,
+        extractor=extractor,
+        schemas=[Triple, Preference],
+    )
+    preference = {"category": "editor", "value": "vim"}
+    input_ = {
+        "messages": [HumanMessage(content="Alice now likes Rust.")],
+        "existing": [
+            (
+                "memory-1",
+                "Triple",
+                {
+                    "subject": "Alice",
+                    "predicate": "likes",
+                    "object": "Python",
+                },
+            ),
+            ("memory-2", "Preference", preference),
+        ],
+        "max_steps": 2,
+    }
+
+    result = manager.invoke(input_)
+
+    assert extractor.payloads[1]["existing"] == [
+        extraction.ExtractedMemory(id="memory-1", content=updated),
+        ("memory-2", "Preference", preference),
+    ]
+    assert result == [
+        extraction.ExtractedMemory(id="memory-1", content=updated),
+        extraction.ExtractedMemory(id="memory-2", content=preference),
+    ]
+
+
+def test_deleted_external_memory_is_not_restored_in_next_step(monkeypatch):
+    removal = RemoveDoc(json_doc_id="memory-1")
+    extractor = SequencedExtractor(
+        [
+            ([removal], [{}]),
+            ([], []),
+        ]
+    )
+    manager, _ = _setup_manager(monkeypatch, extractor=extractor)
+
+    result = manager.invoke(_input())
+
+    assert extractor.payloads[1]["existing"] == []
+    assert result == [
+        extraction.ExtractedMemory(id="memory-1", content=removal),
+    ]


### PR DESCRIPTION
Closes #55.

## Summary

Postgres-backed stores deserialize persisted Pydantic content as dictionaries. `MemoryManager` initially passes those memories to Trustcall as `(id, schema_name, content)` triples, but after the first extraction step unchanged memories were reduced to `(id, content)` pairs. On the next step, Trustcall treated the dictionary as a Pydantic model and called `__repr_name__()`, causing the reported crash.

This change:

- preserves the original `(id, schema_name, content)` tuple for unchanged externally loaded memories between extraction steps;
- tracks IDs modified by inserts, updates, or removals so stale persisted content is never restored;
- applies the same behavior to synchronous and asynchronous managers;
- aligns the public memory-content types with the dictionaries already returned by persistent stores;
- leaves the public `ExtractedMemory` response shape unchanged.

## Regression coverage

- unchanged Postgres-style dictionary memory retains its schema in step two;
- synchronous and asynchronous extraction paths behave identically;
- an updated memory keeps its new Pydantic content instead of restoring stale stored data;
- a second, unchanged schema retains its own schema name;
- a deleted external memory is not reintroduced in the next step.

## Verification

```text
uv run pytest -q tests/test_memory_manager.py
4 passed

uv run pytest -q --ignore=tests/test_docstring_examples.py
34 passed

uv run ruff check src/langmem/knowledge/extraction.py \
  tests/test_memory_manager.py
All checks passed

uv run ruff format --check src/langmem/knowledge/extraction.py \
  tests/test_memory_manager.py
2 files already formatted
```

The unfiltered full suite reaches the same 27 failures in
`tests/test_docstring_examples.py`; each fails before executing the example
because the configured LangSmith token receives HTTP 401 while opening the
remote test dataset. No changed test or offline test fails.

## AI assistance

AI assisted with investigation, implementation review, and test drafting. The
author reviewed the diff and ran every verification command listed above.